### PR TITLE
Fix tally input

### DIFF
--- a/components/turf/TallyRow.tsx
+++ b/components/turf/TallyRow.tsx
@@ -3,7 +3,7 @@ import {ChangeEventHandler, FC, KeyboardEventHandler, useRef} from 'react';
 import './turf.css';
 import {TallyEntry} from '@/components/turf/TallyList';
 import TallyCounter from '@/components/turf/TallyCounter';
-import {formatEuros, parseCents} from '@/components/turf/euroUtil';
+import {formatEuros, parseCents, parseEuros} from '@/components/turf/euroUtil';
 
 type TurfRowProps = {
     entry: TallyEntry,
@@ -34,7 +34,7 @@ const TallyRow: FC<TurfRowProps> = ({entry, changeEntry}) => {
 
     const fixCents = () => {
         if (euroRef.current) {
-            const value = parseCents(euroRef);
+            const value = parseEuros(euroRef);
             if (!isNaN(value)) {
                 euroRef.current.value = formatEuros(value);
             }

--- a/components/turf/turf.css
+++ b/components/turf/turf.css
@@ -127,9 +127,8 @@
 .tallyInput {
     color: black;
     overflow: hidden;
-    text-indent: 2mm;
+    padding-right: 2mm;
     text-align: right;
-    direction: rtl;
 }
 
 .tallyCount {


### PR DESCRIPTION
Fixed rtl css hack breaking text input.
Fixed cents being converted to euros in the tally list.