### PR TITLE
Prevent API routes from being cached

### DIFF
--- a/app/api/bafko/route.ts
+++ b/app/api/bafko/route.ts
@@ -1,8 +1,10 @@
-'use server';
+export const dynamic = 'force-dynamic';
+
 import {NextResponse} from 'next/server';
 import {getSheetValues, SheetValues} from '@/lib/GoogleApi';
 
 const getBafkos = async (): Promise<SheetValues | null> => {
+    "use server";
     if (process?.env?.BAFKO_SHEET_ID && process?.env?.BAFKO_SHEET_RANGE) {
         return getSheetValues(process.env.BAFKO_SHEET_ID, process.env.BAFKO_SHEET_RANGE);
     }
@@ -10,6 +12,7 @@ const getBafkos = async (): Promise<SheetValues | null> => {
 };
 
 export async function GET() {
+    "use server";
     const data = await getBafkos();
     if (data) {
         const random_index = Math.floor(Math.random() * data.length);

--- a/app/api/bak/route.ts
+++ b/app/api/bak/route.ts
@@ -1,5 +1,6 @@
-'use server';
+export const dynamic = 'force-dynamic';
 
 export async function GET() {
+    "use server";
     return new Response(`${Math.random() < 0.17 ? "Trek bak" : "No spang"}`);
 }

--- a/app/api/week/route.ts
+++ b/app/api/week/route.ts
@@ -1,4 +1,4 @@
-'use server';
+export const dynamic = 'force-dynamic';
 
 import dayjs from 'dayjs';
 import weekOfYear from 'dayjs/plugin/weekOfYear';
@@ -6,5 +6,6 @@ import weekOfYear from 'dayjs/plugin/weekOfYear';
 dayjs.extend(weekOfYear);
 
 export async function GET() {
+    "use server";
     return new Response(`${dayjs().week()}`);
 }


### PR DESCRIPTION
Caching currently prevents some API endpoints from working correctly.
Forcing dynamic rendering of these routes should prevent stale values.