### PR TITLE
Fix missing redirects

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -4,13 +4,13 @@ const nextConfig = {
         return [
             {
                 source: '/declaratie',
-                destination: process?.env?.DECLARATIE_REDIRECT,
-                permanent: true,
+                destination: process?.env?.DECLARATIE_REDIRECT ?? '/',
+                permanent: false,
             },
             {
                 source: '/planning',
-                destination: process?.env?.PLANNING_REDIRECT,
-                permanent: true,
+                destination: process?.env?.PLANNING_REDIRECT ?? '/',
+                permanent: false,
             },
         ];
     },


### PR DESCRIPTION
Send missing redirects to homepage.
This is also necessary to pass the build in pipelines.