### PR TITLE
Encode service client key in base 64

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,7 +5,7 @@ TURF_SHEET_RANGE= Google Sheets range containing valid tally entries, such as A1
 PILS_PRIJS= The cost of a standard beer in cents, like 338
 SHEETS_API_KEY= Google Cloud API key (https://cloud.google.com/docs/authentication/api-keys#create)
 SERVICE_CLIENT_EMAIL= Email of Google Cloud API service account (https://cloud.google.com/iam/docs/service-accounts-create?hl=en#creating)
-SERVICE_CLIENT_KEY= Private key of Google Cloud API service account
+SERVICE_CLIENT_KEY= Base 64 encoded private key of Google Cloud API service account
 LICHTING_FOTO_PREFIX= The path prefix for the lichting photos, such as: lichtingfotos
 LICHTING_FOTO_LIST= A comma separated list of the photos to use in the lichting photos folder, such as: 0.jpg,1.jpg
 DECLARATIE_REDIRECT= Redirect url for /declaratie

--- a/lib/GoogleApi.ts
+++ b/lib/GoogleApi.ts
@@ -1,10 +1,11 @@
 'use server';
 import {google, sheets_v4} from 'googleapis';
 import {GaxiosResponse} from 'gaxios';
+import {decodeBase64} from "@/lib/util";
 
 function getJwt() {
     return new google.auth.JWT(
-        process.env.SERVICE_CLIENT_EMAIL, undefined, process.env.SERVICE_CLIENT_KEY,
+        process.env.SERVICE_CLIENT_EMAIL, undefined, decodeBase64(process.env.SERVICE_CLIENT_KEY),
         ['https://www.googleapis.com/auth/spreadsheets']
     );
 }

--- a/lib/util.ts
+++ b/lib/util.ts
@@ -1,0 +1,6 @@
+import {Buffer} from "node:buffer";
+
+export function decodeBase64(data: string | undefined): string | undefined {
+    if (data === undefined) return undefined;
+    return Buffer.from(data, 'base64').toString('utf8');
+}


### PR DESCRIPTION
The service key seemed to be giving problems when deployed in a Docker container.
Encoding it in base 64 fixed the issue in local testing.