### PR TITLE
Fix oAuth callback redirect

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,4 +14,3 @@ AUTH_SECRET= A secret used for encrypting cookies and tokens, generated using "o
 AUTH_GOOGLE_ID= The OAuth client ID found at console.cloud.google.com/apis/credentials
 AUTH_GOOGLE_SECRET= The OAuth client secret found at console.cloud.google.com/apis/credentials
 AUTH_GOOGLE_REDIRECT= URL to redirect to after Google auth
-GOOGLE_CLIENT_SECRETS_PATH= Path to a json file, erh, I mean, secure database containing the active client tokens

--- a/app/api/auth/callback/google/route.ts
+++ b/app/api/auth/callback/google/route.ts
@@ -15,5 +15,5 @@ export async function GET(request: NextRequest) {
 
     // Navigate the user back to the page from where they logged in
     const redirectCookie = cookies().get(redirect_cookie_name);
-    return Response.redirect(new URL(redirectCookie?.value ?? "/", request.url));
+    return Response.redirect(new URL(redirectCookie?.value ?? "/", "https://dispuutbagger.nl"));
 }


### PR DESCRIPTION
The callback endpoint redirected to the internal Docker network address. This has now been changed to the public host name.